### PR TITLE
Add encoding utilities

### DIFF
--- a/carp/examples/encodings/README.md
+++ b/carp/examples/encodings/README.md
@@ -1,0 +1,9 @@
+# Usage
+
+The scripts in this folder generate encodings en-masse from the Story-Critique dataset mentioned in the CARP paper. By default, the scripts use the CARP-L model (with Roberta-Large encoders). They expect the model checkpoint to be in the path "checkpoints/carp_L". The checkpoint for CARP-L trained on the Story-Critique dataset can be found on [the eye](https://the-eye.eu/public/AI/models/CARP/CARP_L.pt). Note that the scripts have relatively long runtimes, so it is reccomended to encode a moderately sized sample of the dataset. These encodings can then be used for visualization or clustering. Additionally, indices for which dataset items were encoded are saved along with the encodings. 
+
+Note that both scripts use checkpoints in case of crashes or interruptions. In order to generate new encodings, please specify FRESH or fresh as an argument.   
+i.e.  
+python -m carp.examples.encodings.encode_reviews FRESH
+  
+Also, keep in mind that because of how saving works, the generated encoding tensor may contain many rows of zero vectors at its end. Code using the encodings must deal with these accordingly.

--- a/carp/examples/encodings/README.md
+++ b/carp/examples/encodings/README.md
@@ -6,4 +6,4 @@ Note that both scripts use checkpoints in case of crashes or interruptions. In o
 i.e.  
 python -m carp.examples.encodings.encode_reviews FRESH
   
-Also, keep in mind that because of how saving works, the generated encoding tensor may contain many rows of zero vectors at its end. Code using the encodings must deal with these accordingly.
+Also, keep in mind that because of how saving works, the generated encoding tensor may contain many rows of zero vectors at its end. Code using the encodings must deal with these accordingly. It is also in float16, so a casting to float32 is reccomended when doing any computations downstream with the generated encodings.

--- a/carp/examples/encodings/encode_passages.py
+++ b/carp/examples/encodings/encode_passages.py
@@ -1,8 +1,147 @@
 import torch
 import numpy as np
 from torch.nn.functional import normalize
+
 import math
+import sys
+from typing import Iterable
 
 from carp.configs import CARPConfig
-from carp.pytorch.model.architectures import *
+from carp.pytorch.model.architectures.carp import CARP
+from carp.pytorch.model.architectures import BaseModel
 from carp.pytorch.data import *
+
+from carp.examples.encodings.util import load_encs, save_encs, chunk
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+def enc_passages(N_SAMPLES : int, force_fresh : bool, CHUNK_SIZE : int, SAVE_EVERY : int,
+    model : BaseModel,
+    txt_data : Iterable[str],
+    N_CTX : int = 512,
+    ind_path : str = "carp/examples/encodings/pass_embedding_inds.pt",
+    enc_path : str = "carp/examples/encodings/passage_encs.pt",
+    random_state : int = 0):
+    """
+    Encodes given number of passages and saves embeddings into a file. Also saves indices of passages that were encoded (with respect to the dataset)
+    Can take a very long time, so saves checkpoints regularly. Automatically tries to load checkpoint by default.
+    
+    :param N_SAMPLES: number of passages to encode
+    :type N_SAMPLES: int
+
+    :param force_fresh: if true, prevents loading of any checkpoints (force a fresh run)
+    :type force_fresh: bool
+
+    :param CHUNK_SIZE: number of passages to encode at once
+    :type CHUNK_SIZE: int
+
+    :param SAVE_EVERY: number of passages to encode before saving checkpoint
+    :type SAVE_EVERY: int
+
+    :param model: model to use for encoding
+    :type model: carp.pytorch.model.architectures.BaseModel
+
+    :param txt_data: iterable of passages to encode
+    :type txt_data: Iterable[str]
+
+    :param N_CTX: context size for encoding (specific to model being used)
+    :type N_CTX: int
+
+    :param ind_path: path to which to save a tensor indexing which passages were encoded
+    :type ind_path: str
+
+    :param enc_path: path to which to save the passage embeddings
+    :type enc_path: str
+
+    :param random_state: random seed used to sample passages from the dataset for encoding
+    :type random_state: int
+    """
+    N_CTX = 512
+    txt_data = [txt[-N_CTX:] for txt in txt_data]
+    LATENT_DIM = model.latent_dim
+
+    N = len(txt_data)
+    
+    # Load a previous run by loading indices then encodings if that works
+    try:
+        assert not force_fresh
+        inds = torch.load(ind_path)
+        assert len(inds) == N_SAMPLES
+
+        passage_encs = load_encs(enc_path).half()
+        crnt_ind = len(passage_encs) # which passage in inds are we at?
+    except:
+        # generate indices of the passages we will use
+        torch.manual_seed(random_state)
+        inds = torch.randperm(N)[:N_SAMPLES]
+        torch.save(inds, ind_path)
+
+        passage_encs = torch.zeros(0, LATENT_DIM).half()
+        crnt_ind = 0
+
+    # Chunk the indices based on chunk size
+    n_chunks = len(inds) // CHUNK_SIZE
+    if n_chunks > 0:
+        ind_chunks = chunk(inds, CHUNK_SIZE)
+    else:
+        ind_chunks = [inds]
+    
+    tokenize = model.passage_encoder.call_tokenizer
+
+    # encode a single batch of txt (list of strings) with passage encoder
+    def encode(txt_batch):
+        tok_out = tokenize(txt_batch)
+        x = tok_out["input_ids"].to(device)
+        mask = tok_out["attention_mask"].to(device)
+        enc_input = BatchElement(x, mask)
+
+        with torch.no_grad():
+            encs = model.encode_passages(enc_input).hidden
+        encs = encs.cpu().half()
+        return encs
+    
+    # save the encodings so far
+    def save():
+        save_encs(passage_encs, enc_path)
+    
+    # iterate through chunks
+    while crnt_ind < N_SAMPLES:
+        which_chunk = crnt_ind // CHUNK_SIZE
+        inds = ind_chunks[which_chunk]
+
+        # Get chunk and encode it
+        passage_batch = [txt_data[i] for i in inds]
+        enc_batch = encode(passage_batch)
+
+        passage_encs = torch.cat([passage_encs, enc_batch])
+        
+        if which_chunk % SAVE_EVERY == 0:
+            print("Progress: [{}/{}]".format(crnt_ind, N_SAMPLES))
+            save()
+        
+        crnt_ind += len(inds)
+    
+    save()
+
+if __name__ == "__main__":
+    # Decide whether or not to do fresh run from command line
+    if len(sys.argv) >= 2:
+        if sys.argv[1] == "FRESH" or sys.argv[1] == "fresh":
+            force_fresh = True
+        else:
+            force_fresh = False
+
+    # Use CARP Large by default
+    print("Load Model...")
+    config = CARPConfig.load_yaml("configs/carp_l.yml")
+    model = CARP(config.model)
+    model.load("checkpoints/CARP_L/")
+    model = model.to(device)
+
+    # And the Story-Critique dataset
+    pipeline = BaseDataPipeline(path="carp/dataset")
+
+    enc_passages(N_SAMPLES = 10000, force_fresh = force_fresh,
+        CHUNK_SIZE = 256, SAVE_EVERY = 5, model = model,
+        txt_data = pipeline.passages, N_CTX = 512, random_state = 0
+    )

--- a/carp/examples/encodings/encode_passages.py
+++ b/carp/examples/encodings/encode_passages.py
@@ -1,0 +1,8 @@
+import torch
+import numpy as np
+from torch.nn.functional import normalize
+import math
+
+from carp.configs import CARPConfig
+from carp.pytorch.model.architectures import *
+from carp.pytorch.data import *

--- a/carp/examples/encodings/encode_reviews.py
+++ b/carp/examples/encodings/encode_reviews.py
@@ -1,0 +1,143 @@
+import torch
+import numpy as np
+from torch.nn.functional import normalize
+
+import math
+import sys
+from typing import Iterable
+
+from carp.configs import CARPConfig
+from carp.pytorch.model.architectures import *
+from carp.pytorch.model.architectures import BaseModel
+from carp.pytorch.data import *
+
+from carp.examples.encodings.util import load_encs, save_encs, chunk
+
+def enc_reviews(N_SAMPLES : int, force_fresh : bool, CHUNK_SIZE : int, SAVE_EVERY : int,
+    model : BaseModel,
+    txt_data : Iterable[str],
+    N_CTX : int = 512,
+    ind_path : str = "carp/examples/encodings/rev_embedding_inds.pt",
+    enc_path : str = "carp/examples/encodings/review_encs.pt",
+    random_state : int = 0):
+    """
+    Encodes given number of reviews and saves embeddings into a file. Also saves indices of reviews that were encoded (with respect to the dataset)
+    Can take a very long time, so saves checkpoints regularly. Automatically tries to load checkpoint by default.
+    
+    :param N_SAMPLES: number of reviews to encode
+    :type N_SAMPLES: int
+
+    :param force_fresh: if true, prevents loading of any checkpoints (force a fresh run)
+    :type force_fresh: bool
+
+    :param CHUNK_SIZE: number of reviews to encode at once
+    :type CHUNK_SIZE: int
+
+    :param SAVE_EVERY: number of reviews to encode before saving checkpoint
+    :type SAVE_EVERY: int
+
+    :param model: model to use for encoding
+    :type model: carp.pytorch.model.architectures.BaseModel
+
+    :param txt_data: iterable of reviews to encode
+    :type txt_data: Iterable[str]
+
+    :param N_CTX: context size for encoding (specific to model being used)
+    :type N_CTX: int
+
+    :param ind_path: path to which to save a tensor indexing which reviews were encoded
+    :type ind_path: str
+
+    :param enc_path: path to which to save the review embeddings
+    :type enc_path: str
+
+    :param random_state: random seed used to sample reviews from the dataset for encoding
+    :type random_state: int
+    """
+    N_CTX = 512
+    txt_data = [txt[-N_CTX:] for txt in txt_data]
+    LATENT_DIM = model.latent_dim
+
+    N = len(txt_data)
+    
+    # Load a previous run by loading indices then encodings if that works
+    try:
+        assert not force_fresh
+        inds = torch.load(ind_path)
+        assert len(inds) == N_SAMPLES
+
+        review_encs = load_encs(enc_path).half()
+        crnt_ind = len(review_encs) # which review in inds are we at?
+    except:
+        # generate indices of the reviews we will use
+        torch.manual_seed(random_state)
+        inds = torch.randperm(N)[:N_SAMPLES]
+        torch.save(inds, ind_path)
+
+        review_encs = torch.zeros(0, LATENT_DIM).half()
+        crnt_ind = 0
+
+    # Chunk the indices based on chunk size
+    n_chunks = len(inds) // CHUNK_SIZE
+    if n_chunks > 0:
+        ind_chunks = chunk(inds, CHUNK_SIZE)
+    else:
+        ind_chunks = [inds]
+    
+    tokenize = model.review_encoder.call_tokenizer
+
+    # encode a single batch of txt (list of strings) with review encoder
+    def encode(txt_batch):
+        tok_out = tokenize(txt_batch)
+        x = tok_out["input_ids"]
+        mask = tok_out["attention_mask"]
+        enc_input = BatchElement(x, mask)
+
+        with torch.no_grad():
+            encs = model.encode_reviews(enc_input).hidden
+        encs = encs.cpu().half()
+        return encs
+    
+    # save the encodings so far
+    def save():
+        save_encs(review_encs, enc_path)
+    
+    # iterate through chunks
+    while crnt_ind < N_SAMPLES:
+        which_chunk = crnt_ind // CHUNK_SIZE
+        inds = ind_chunks[which_chunk]
+
+        # Get chunk and encode it
+        review_batch = [txt_data[i] for i in inds]
+        enc_batch = encode(review_batch)
+
+        review_encs = torch.cat([review_encs, enc_batch])
+        
+        if which_chunk % SAVE_EVERY == 0:
+            print("Progress: [{}/{}]".format(crnt_ind, N_SAMPLES))
+            save()
+        
+        crnt_ind += len(inds)
+    
+    save()
+
+if __name__ == "__main__":
+    if len(sys.argv) >= 2:
+        if sys.argv[1] == "FRESH" or sys.argv[1] == "fresh":
+            force_fresh = True
+        else:
+            force_fresh = False
+
+    # Use CARP Large by default
+    print("Load Model...")
+    config = CARPConfig.load_yaml("configs/carp_l.yml")
+    model = CARP(config)
+    model.load("checkpoints/CARP_L")
+
+    # And the Story-Critique dataset
+    pipeline = BaseDataPipeline(path="carp/dataset")
+
+    enc_reviews(N_SAMPLES = 10000, force_fresh = force_fresh,
+        CHUNK_SIZE = 256, SAVE_EVERY = 5, model = model,
+        txt_data = pipeline.reviews, N_CTX = 512, random_state = 0)
+    )

--- a/carp/examples/encodings/util.py
+++ b/carp/examples/encodings/util.py
@@ -1,0 +1,26 @@
+import torch
+
+# load review encodings
+def load_encs(path):
+    # remove trailing zero vectors
+    def remove_zeros(T):
+        bound = len(T)
+        for i in reversed(range(len(T))):
+            if T[i].sum() > 0.25: # i.e. not 0
+                bound = i + 1
+                break
+        print("{} encodings found.".format(bound))
+        return T[:bound]
+    
+    print("Loading Encodings...")
+    review_encs = torch.load(path)
+
+    return remove_zeros(review_encs)
+
+# Save encodings
+def save_encs(encs, path):
+    torch.save(encs, path)
+
+# chunk iterable into chunks of size n
+def chunk(l, n):
+    return [l[i:i+n] for i in range(0, len(l), n)]


### PR DESCRIPTION
Added example scripts that can be used to generate passage or review encodings en masse, with indexes of which dataset items were encoded. This is useful for many things so I think it should be incorporated into main branch.