### PR TITLE
Added default setting for review encoding

### DIFF
--- a/carp/examples/encodings/encode_passages.py
+++ b/carp/examples/encodings/encode_passages.py
@@ -131,6 +131,7 @@ def enc_passages(
 
 if __name__ == "__main__":
     # Decide whether or not to do fresh run from command line
+    force_fresh = False
     if len(sys.argv) >= 2:
         if sys.argv[1] == "FRESH" or sys.argv[1] == "fresh":
             force_fresh = True

--- a/carp/examples/encodings/encode_reviews.py
+++ b/carp/examples/encodings/encode_reviews.py
@@ -131,6 +131,7 @@ def enc_reviews(
 
 if __name__ == "__main__":
     # Decide whether or not to do fresh run from command line
+    force_fresh = False
     if len(sys.argv) >= 2:
         if sys.argv[1] == "FRESH" or sys.argv[1] == "fresh":
             force_fresh = True


### PR DESCRIPTION
Made error of not creating a default value for "force_fresh". This means that running script without command line argument of "FRESH" resulted in no value being set, causing a runtime error. There was effectively no way to have a non fresh run unless a redundant argument was passed.