### PR TITLE
Fixed issue with context length using characters instead of tokens.

### DIFF
--- a/carp/examples/encodings/encode_passages.py
+++ b/carp/examples/encodings/encode_passages.py
@@ -22,7 +22,6 @@ def enc_passages(
     SAVE_EVERY: int,
     model: BaseModel,
     txt_data: Iterable[str],
-    N_CTX: int = 512,
     ind_path: str = "carp/examples/encodings/pass_embedding_inds.pt",
     enc_path: str = "carp/examples/encodings/passage_encs.pt",
     random_state: int = 0,
@@ -61,8 +60,6 @@ def enc_passages(
     :param random_state: random seed used to sample passages from the dataset for encoding
     :type random_state: int
     """
-    N_CTX = 512
-    txt_data = [txt[-N_CTX:] for txt in txt_data]
     LATENT_DIM = model.latent_dim
 
     N = len(txt_data)

--- a/carp/examples/encodings/encode_reviews.py
+++ b/carp/examples/encodings/encode_reviews.py
@@ -22,7 +22,6 @@ def enc_reviews(
     SAVE_EVERY: int,
     model: BaseModel,
     txt_data: Iterable[str],
-    N_CTX: int = 512,
     ind_path: str = "carp/examples/encodings/rev_embedding_inds.pt",
     enc_path: str = "carp/examples/encodings/review_encs.pt",
     random_state: int = 0,
@@ -49,9 +48,6 @@ def enc_reviews(
     :param txt_data: iterable of reviews to encode
     :type txt_data: Iterable[str]
 
-    :param N_CTX: context size for encoding (specific to model being used)
-    :type N_CTX: int
-
     :param ind_path: path to which to save a tensor indexing which reviews were encoded
     :type ind_path: str
 
@@ -61,8 +57,6 @@ def enc_reviews(
     :param random_state: random seed used to sample reviews from the dataset for encoding
     :type random_state: int
     """
-    N_CTX = 512
-    txt_data = [txt[-N_CTX:] for txt in txt_data]
     LATENT_DIM = model.latent_dim
 
     N = len(txt_data)

--- a/carp/examples/pseudolabels/umap_clustering.py
+++ b/carp/examples/pseudolabels/umap_clustering.py
@@ -12,7 +12,7 @@ from carp.pytorch.model.architectures.carp import CARP
 from carp.configs import CARPConfig
 
 from carp.examples.encodings.encode_reviews import enc_reviews
-from carp.examples.visualization.vis_util import scatter_with_names
+from carp.examples.visualization.plot_util import scatter_with_names
 
 if __name__ == "__main__":
     print("Load Dataset...")
@@ -34,18 +34,17 @@ if __name__ == "__main__":
         print("Load Model...")
         config = CARPConfig.load_yaml("configs/carp_l.yml")
         model = CARP(config.model)
-        model.load("checkpoints/CARP_L/")
+        model.load("checkpoints/CARP_L")
         model = model.to(device)
 
         print("Generate Encodings...")
         enc_reviews(
             N_SAMPLES = 10000,
             force_fresh = True,
-            CHUNK_SIZE = 256,
+            CHUNK_SIZE = 128,
             SAVE_EVERY = 5,
             model = model,
             txt_data = pipeline.reviews,
-            N_CTX = 512,
             ind_path = "carp/examples/pseudolabels/embedding_inds.pt",
             enc_path = "carp/examples/pseudolabels/review_encs.pt",
             random_state = 69,

--- a/carp/pytorch/data/__init__.py
+++ b/carp/pytorch/data/__init__.py
@@ -62,8 +62,6 @@ class BaseDataPipeline(Dataset):
                     size -= 1
                 else:
                     i += 1
-        self.passages = passages
-        self.reviews = reviews
 
     def __getitem__(self, index: int) -> Tuple[str, str]:
         return self.passages[index], self.reviews[index]

--- a/carp/pytorch/model/encoders/__init__.py
+++ b/carp/pytorch/model/encoders/__init__.py
@@ -92,6 +92,8 @@ class BaseEncoder(nn.Module):
             self.preprocess(string_batch),
             return_tensors="pt",  # Will they ever _not_ be pytorch tensors?
             padding=True,
+            truncation=True,
+            max_length=self.tokenizer.model_max_length
         )
 
     def forward(self, inputs_embeds=False, **kwargs):


### PR DESCRIPTION
In several scripts, string length was being used instead of number of tokens for context truncation. I have not checked the entire codebase for more instances of this issue (these may exist) but have resolved the cases within the example scripts. Additionally, the tokenizer in the BaseEncoder has been updated to have automatic truncation to model context length. A one-off bug within data pipeline that seems to be result of old code being left in has also been resolved.