### PR TITLE
Update cosine_sim implementation

### DIFF
--- a/carp/pytorch/model/architectures/__init__.py
+++ b/carp/pytorch/model/architectures/__init__.py
@@ -201,7 +201,7 @@ class BaseModel(nn.Module):
         self,
         x: TensorType[-1, "latent_dim"],
         y: TensorType[-1, "latent_dim"],
-        normalize=False,
+        normalize=True,
     ):
         """
         Computes the cosine similarity between two sets of vectors x,y
@@ -215,7 +215,7 @@ class BaseModel(nn.Module):
             x = F.normalize(x)
             y = F.normalize(y)
         # small term added to avoid nans in low precision softmax
-        return torch.abs(x @ y.T) + 1e-6
+        return (x @ y.T) + 1e-6
 
     def contrastive_loss(
         self, x: TensorType[-1, "latent_dim"], y: TensorType[-1, "latent_dim"]


### PR DESCRIPTION
Had an absolute value so the cosine similarity would always be positive, removed that...

Also, don't know why `normalize=False` is the default, I think `normalize=True` is a better default. If you are not normalized, you need it to be, and if it is already normalized to a unit vector, it shouldn't do anything, right? so `normalize=True` sounds like a better default to me...
