### PR TITLE
Ctx fix

### DIFF
--- a/carp/pytorch/data/utils/data_util.py
+++ b/carp/pytorch/data/utils/data_util.py
@@ -78,9 +78,6 @@ def filter_empty(passages: List[str], reviews: List[str]) -> None:
 def create_tok(tokenizer: Callable, context_len: int):
     @typechecked
     def _tok(string_batch: Iterable[str]) -> BatchEncoding:
-        for i, _ in enumerate(string_batch):
-            if len(string_batch[i]) > context_len:
-                string_batch[i] = string_batch[i][-context_len:]
         if not isinstance(string_batch, list):
             string_batch = list(string_batch)
         return tokenizer(string_batch)

--- a/carp/pytorch/model/architectures/carp_vicreg.py
+++ b/carp/pytorch/model/architectures/carp_vicreg.py
@@ -186,6 +186,6 @@ class CARPVicregTrainer(BaseTrainer):
             "Loss/Train": loss,
             "Loss/Vicreg": vicreg_loss,
             "Acc/Forward": forward_output["forward_acc"],
-            "Acc/Top_5_Forward": forward_output["top_5_Acc"],
+            "Acc/Top_5_Forward": forward_output["top_k_acc"],
             "Model/logit_scale": self.model.logit_scale.sum(),
         }


### PR DESCRIPTION
Two fixes

Context Length Fix:
- Any trainer inheriting from BaseTrainer was calling create_tok, a method that truncates all strings to only look at last n_ctx (generally 512) characters, as opposed to last n_ctx tokens
- BaseEncoder was fixed previously to implicitly truncate when required
- create_tok is now just lowering data quality by cutting all inputted strings short
- This bug likely effected many training results

Vicreg Trainer:
- Previous KeyError bug in BaseTrainer was patched in BaseTrainer but not in other trainers
- Changed a key in vicreg trainer to reflect the patch to BaseTrainer